### PR TITLE
Add example openstack config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,16 +1,16 @@
 # vim: sw=2:ts=2:et:ft=ruby
 
 boxes = [
-  {:name => 'precise',  :libvirt => 'fm-ubuntu1204', :rackspace => /Ubuntu.*12\.04/},
-  {:name => 'squeeze',  :libvirt => 'fm-debian6',    :rackspace => /Debian.*6/},
-  {:name => 'wheezy',   :libvirt => 'fm-debian7',    :rackspace => /Debian.*7/},
+  {:name => 'precise',  :libvirt => 'fm-ubuntu1204', :rackspace => /Ubuntu.*12\.04/, :username => 'ubuntu'},
+  {:name => 'squeeze',  :libvirt => 'fm-debian6',    :rackspace => /Debian.*6/,      :username => 'debian'},
+  {:name => 'wheezy',   :libvirt => 'fm-debian7',    :rackspace => /Debian.*7/,      :username => 'debian'},
   {:name => 'f19',      :libvirt => 'fm-fedora19',   :rackspace => /Fedora.*19/, :pty => true},
   {:name => 'f20',      :libvirt => 'fm-fedora20',   :rackspace => /Fedora.*20/, :pty => true},
   {:name => 'el6',      :libvirt => 'fm-centos64',   :rackspace => /CentOS.*6\.4/, :default => true, :pty => true},
 ]
 
 if ENV['box']
-  boxes << {:name => ENV['box'], :libvirt => ENV['box'], :rackspace => ENV['box']}
+  boxes << {:name => ENV['box'], :libvirt => ENV['box'], :rackspace => ENV['box'], :username => ENV['box']}
 end
 
 Vagrant.configure("2") do |config|
@@ -33,6 +33,27 @@ Vagrant.configure("2") do |config|
         p.image = box[:rackspace]
         override.ssh.pty = true if box[:pty]
       end
+
+      # ~/.vagrant.d/Vagrantfile will need
+      # config.ssh.private_key_path = "~/.ssh/id_greg"        # private key for keypair below
+
+      config.vm.provider :openstack do |p, override|
+        override.vm.box = 'dummy'
+        p.server_name   = machine.vm.hostname
+        p.flavor        = /m1.tiny/
+        p.image         = box[:rackspace] # Might as well use consistent image names
+        p.ssh_username  = box[:username]  # login for the VM
+
+        # ~/.vagrant.d/Vagrantfile will need
+        # p.username     = "admin"                            # e.g. "#{ENV['OS_USERNAME']}"
+        # p.api_key      = "secret"                           # e.g. "#{ENV['OS_PASSWORD']}"
+        # p.endpoint     = "http://amethyst:5000/v2.0/tokens" # e.g. "#{ENV['OS_AUTH_URL']}/tokens"
+        # p.keypair_name = "Greg"                             # as stored in Nova
+
+        # You may need
+        # p.floating_ip = '172.20.10.160' # Must be hardcoded, cannot ask Openstack for an IP
+      end
+
     end
   end
 end


### PR DESCRIPTION
The comments are what we might put in the Jenkins ~/.vagrant.d/Vagrantfile if we used this, but I'm inclined to leave them here for now as a "how-to" sort of thing.

Note setting the floating_ip manually is annoying as hell - it shouldn;t be necessary on something like OS1-internal which gives out routeable IPs by default, but otherwise you need it for Vagrant to reach the box.
