### PR TITLE
fixing Red Hat version detection

### DIFF
--- a/os_helper.bash
+++ b/os_helper.bash
@@ -26,7 +26,7 @@ tSetOSVersion() {
       OS_VERSION=$(rpm -q --queryformat '%{VERSION}' fedora-release)
     elif tIsRedHatCompatible; then
       _PKG=$(rpm -qa '(redhat|sl|centos|oraclelinux)-release(|-server|-workstation|-client|-computenode)')
-      OS_VERSION=$(rpm -q --queryformat '%{RELEASE}' $_PKG | awk -F. '{print $1}')
+      OS_VERSION=$(rpm -q --queryformat '%{VERSION}' $_PKG | grep -o '^[0-9]*')
     elif tIsUbuntuCompatible; then
       tPackageExists lsb-release || tPackageInstall lsb-release
       OS_VERSION=$(. /etc/os-release; echo $VERSION_ID)


### PR DESCRIPTION
Tested both on CentOS and RHEL. Gives "6".
