### PR TITLE
Fix installation of compute resource packages

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -133,8 +133,12 @@ EOF
 
 @test "install all compute resources" {
   packages="foreman-console foreman-libvirt foreman-vmware foreman-ovirt"
-  yum info foreman-gce >/dev/null 2>&1 && packages="$packages foreman-gce"
+  tPackageAvailable foreman-gce && packages="$packages foreman-gce"
   tPackageInstall $packages
+}
+
+@test "check web app is still up" {
+  curl -sk "https://localhost$URL_PREFIX/users/login" | grep -q login-form
 }
 
 @test "restart foreman" {

--- a/os_helper.bash
+++ b/os_helper.bash
@@ -65,6 +65,16 @@ tIsUbuntu() {
   tIsUbuntuCompatible
 }
 
+tPackageAvailable() {
+  if tIsRedHatCompatible; then
+    yum info "$1" >/dev/null 2>&1
+  elif tIsDebianCompatible; then
+    apt-cache show "$1" >/dev/null 2>&1
+  else
+    false # not implemented
+  fi
+}
+
 tPackageExists() {
   if tIsRedHatCompatible; then
     rpm -q "$1" >/dev/null
@@ -77,9 +87,9 @@ tPackageExists() {
 
 tPackageInstall() {
   if tIsRedHatCompatible; then
-    yum -y install "$1"
+    yum -y install $*
   elif tIsDebianCompatible; then
-    apt-get install -y "$1"
+    apt-get install -y $*
   else
     false # not implemented
   fi
@@ -87,9 +97,9 @@ tPackageInstall() {
 
 tPackageUpgrade() {
   if tIsRedHatCompatible; then
-    yum -y upgrade "$1"
+    yum -y upgrade $*
   elif tIsDebianCompatible; then
-    apt-get upgrade -y "$1"
+    apt-get upgrade -y $*
   else
     false # not implemented
   fi


### PR DESCRIPTION
Using $\* instead of $1 is the main fix here, plus a fix for foreman-gce on Debian.

Tested on EL6 and Debian 7.
