### PR TITLE
Increase RAM to 2GB for Rackspace, as swap has been removed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
       machine.vm.provider :rackspace do |p, override|
         override.vm.box = 'dummy'
         p.server_name = machine.vm.hostname
-        p.flavor = /1GB/
+        p.flavor = /2GB/
         p.image = box[:image_name]
         override.ssh.pty = true if box[:pty]
       end


### PR DESCRIPTION
I'd hoped it was intermittent, but it's happening regularly: http://ci.theforeman.org/job/systest_foreman/1138/console

Seems to be since Rackspace removed swap from their default images.
