### PR TITLE
Ignore bug #6520 on Debian 6/Ubuntu 12.04

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -147,6 +147,7 @@ EOF
 
 @test "check for no changes when running the installer" {
   [ x$FOREMAN_VERSION = "x1.5" -o x$FOREMAN_VERSION = "x1.4" ] && skip "Only supported on 1.6+"
+  tIsDebianCompatible && [ x$OS_RELEASE = xsqueeze -o x$OS_RELEASE = xprecise ] && skip "Known bug #6520"
   foreman-installer --no-colors -v --detailed-exitcodes
   [ $? -eq 0 ]
 }


### PR DESCRIPTION
Caused by installation of javascript-common via Passenger package deps, but
ordering within pl-apache doesn't ensure the new config is purged on the first
run.  Newer versions don't install this.
