### PR TITLE
Add support for PUPPET_REPO=nightly to install nightly Puppet builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ specified:
   FOREMAN_REPO for the main Foreman URL
 * MODULE_PATH: override the location of modules used for installation.
 
+When using fb-install-plpuppet.bats, the following environment variables can be
+specified:
+
+* PUPPET_REPO: either "nightly" or "stable" (default)
+
 Vagrant support
 ---------------
 

--- a/fb-install-plpuppet.bats
+++ b/fb-install-plpuppet.bats
@@ -20,6 +20,28 @@ load os_helper
   fi
 }
 
+@test "setup puppetlabs nightly repos" {
+  [ x${PUPPET_REPO} = xnightly ] || skip "PUPPET_REPO is not set to nightly"
+  tSetOSVersion
+  if tIsFedora; then
+    curl -o /etc/yum.repos.d/puppet-nightlies.repo \
+      http://nightlies.puppetlabs.com/puppet-latest/repo_configs/rpm/pl-puppet-latest-fedora-${OS_VERSION}-$(uname -i).repo
+    curl -o /etc/yum.repos.d/facter-nightlies.repo \
+      http://nightlies.puppetlabs.com/facter-latest/repo_configs/rpm/pl-facter-latest-fedora-${OS_VERSION}-$(uname -i).repo
+  elif tIsRHEL; then
+    curl -o /etc/yum.repos.d/puppet-nightlies.repo \
+      http://nightlies.puppetlabs.com/puppet-latest/repo_configs/rpm/pl-puppet-latest-el-${OS_VERSION}-$(uname -i).repo
+    curl -o /etc/yum.repos.d/facter-nightlies.repo \
+      http://nightlies.puppetlabs.com/facter-latest/repo_configs/rpm/pl-facter-latest-el-${OS_VERSION}-$(uname -i).repo
+  elif tIsDebianCompatible; then
+    curl -o /etc/apt/sources.list.d/puppet-nightlies.list \
+      http://nightlies.puppetlabs.com/puppet-latest/repo_configs/deb/pl-puppet-latest-${OS_RELEASE}.list
+    curl -o /etc/apt/sources.list.d/facter-nightlies.list \
+      http://nightlies.puppetlabs.com/facter-latest/repo_configs/deb/pl-facter-latest-${OS_RELEASE}.list
+    apt-get update
+  fi
+}
+
 @test "upgrade puppet package" {
   if tPackageExists puppet; then
     tPackageUpgrade puppet\* facter\*


### PR DESCRIPTION
<pre>
[dcleal@cobalt foreman-bats]$ vagrant ssh wheezy -c 'dpkg -l puppet facter'
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                               Version                               Architecture Description
+++-==================================-=====================================-============-=======================================================================================================
ii  facter                             2.2.0.2-1puppetlabs1                  all          Ruby module for collecting simple facts about a host operating system
ii  puppet                             3.6.2.1080-1puppetlabs1               all          Centralized configuration management - agent startup and compatibility scripts
[dcleal@cobalt foreman-bats]$ vagrant ssh el6 -c 'rpm -q puppet facter'
puppet-3.6.2.1080-1.el6.noarch
facter-2.2.0.2-1.el6.x86_64
</pre>


Replaces what I was doing in Jenkins with my old copr builds.

(https://groups.google.com/forum/#!topic/puppet-dev/X1ekljb5x8w announcement)
