### PR TITLE
Adding beakerlib support to our tests

### DIFF
--- a/beakerlib_helper.bash
+++ b/beakerlib_helper.bash
@@ -1,0 +1,12 @@
+# vim: ft=sh:sw=2:et
+
+# create dummy functions for case beakerlib is not present
+rlPhaseStartTest() {
+}
+rlPhaseEnd() {
+}
+
+# source beakerlib support
+[ -f /var/lib/beakerlib/beakerlib.sh ] && source /var/lib/beakerlib/beakerlib.sh
+[ -f /usr/share/beakerlib/beakerlib.sh ] && source /usr/share/beakerlib/beakerlib.sh
+


### PR DESCRIPTION
This adds some extra logging output via beakerlib which should show up in the
Bekar UI nicely (test name, what passed, what failed, progress meter). It must
work on systems without beakerlib (Debian, Ubuntu) as well (it should not break
anything).

DO NOT MERGE

I am testing this on our beaker instance.
