### PR TITLE
Set permissive when installing oVirt

### DIFF
--- a/fb-install-ovirt.bats
+++ b/fb-install-ovirt.bats
@@ -52,6 +52,13 @@ setup() {
   fi
 }
 
+# There are known bugs in oVirt 3.5 All-In-One setup with SELinux
+@test "set permissive SELinux" {
+  if tIsRedHatCompatible; then
+    setenforce 0
+  fi
+}
+
 @test "install all-in-one installer" {
   tPackageInstall ovirt-engine ovirt-engine-setup-plugin-allinone
 }


### PR DESCRIPTION
There are blocker bugs in oVirt 3.5 which prevents from staring a VM. Quite a
blocker, for a virtual solution :-)

I know this is bad, but we are not testing oVirt here. We are testing rbovirt
integration and Foreman. Set to permissive, the denials are still there, but it
does not block me from running tests and using oVirt.
