### PR TITLE
CentOS7 image needs biosdevname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,11 @@ Vagrant.configure("2") do |config|
 
       machine.vm.provider :libvirt do |p, override|
         override.vm.box = "#{box[:libvirt]}"
-        override.vm.box_url = "http://m0dlx.com/files/foreman/boxes/#{box[:libvirt].sub(/^fm-/, '')}.box"
+        if box[:libvirt] == 'fm_centos70' 
+          override.vm.box_url = 'https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.0/centos-7.0.box'
+        else
+          override.vm.box_url = "http://m0dlx.com/files/foreman/boxes/#{box[:libvirt].sub(/^fm-/, '')}.box"
+        end
         p.memory = 1024
       end
 


### PR DESCRIPTION
After repeatedly hitting this error using the default box for el7:

```
==> el7: Mounting NFS shared folders...
==> el7: Configuring and enabling network interfaces...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

/usr/sbin/biosdevname --policy=all_ethN -i bash: line 2: /usr/sbin/biosdevname: No such file or directory

Stdout from the command:



Stderr from the command:

bash: line 2: /usr/sbin/biosdevname: No such file or directory
```

I decided to try to redownload the image in case it was corrupted, but still got the issue constantly. I changed the image to [this one](https://download.gluster.org/pub/gluster/purpleidea/vagrant/centos-7.0/centos-7.0.box) and all of a sudden the error went away. I thought about installing biosdevtools on the provision step but it turns out it's needed before then, so the image has to include it.

This is probably a bad solution and just a patch as I'm assuming @domcleal repo images want to come with biosdevtools by default, maybe just mirroring the image from m0dlx is a good solution.