### PR TITLE
Fixed heredoc for oVirt tests

### DIFF
--- a/fb-install-ovirt.bats
+++ b/fb-install-ovirt.bats
@@ -148,7 +148,7 @@ FOREPO
 
 @test "perform integration tests" {
   test -d rbovirt || git clone https://github.com/abenari/rbovirt
-cat >rbovirt/spec/endpoint.yml <<'ENDPOINT'
+cat >rbovirt/spec/endpoint.yml <<ENDPOINT
 url: "https://$(hostname -f)/api"
 user: "admin@internal"
 password: "ovirt"


### PR DESCRIPTION
Tests were failing because the hostname were not rendered right. Please quick
merge, thanks!
