### PR TITLE
Fixed timezone issue in the last report test

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -186,7 +186,7 @@ EOF
 }
 
 @test "check host is registered" {
-  hammer $(tHammerCredentials) host info --name $(hostname -f) | egrep "Last report.*$(date +%Y/%m/%d)"
+  hammer $(tHammerCredentials) host info --name $(hostname -f) | egrep "Last report:.*[[:alnum:]]+"
 }
 
 # ENC / Puppet class apply tests


### PR DESCRIPTION
We've occasionally seen errors when test was executed in US datacenters. This
was due the fact that we were comparing UTC and non-UTC outputs.

Thanks @domcleal for spotting this.
