### PR TITLE
hammer host update --puppet-class-ids is now used for associations

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -216,7 +216,8 @@ EOF
 @test "assign puppet class to host" {
   [ x$FOREMAN_VERSION = "x1.4" ] && skip "Only supported on 1.5+"
   id=$(hammer $(tHammerCredentials) --csv puppet-class list --search 'name = ntp' | tail -n1 | cut -d, -f1)
-  hammer $(tHammerCredentials) host update --puppetclass-ids $id --name $(hostname -f)
+  pc_ids=$(hammer $(tHammerCredentials) host update --help | awk '/class-ids/ {print $1}')
+  hammer $(tHammerCredentials) host update $pc_ids $id --name $(hostname -f)
 }
 
 @test "apply class with puppet agent" {


### PR DESCRIPTION
Since https://github.com/theforeman/hammer-cli-foreman/pull/157, the argument
has changed from --puppetclass-ids to --puppet-class-ids.

Looks up the argument name from help output as it's hard to judge which
version of Hammer is being used.
