### PR TITLE
Fix package names for Debian based OSes

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -78,7 +78,11 @@ setup() {
 }
 
 @test "update important system packages" {
-  tPackageUpgrade bash openssh ca-certificates sudo selinux-policy\* yum\* abrt\* sos
+  if tIsRedHatCompatible; then
+    tPackageUpgrade bash openssh ca-certificates sudo selinux-policy\* yum\* abrt\* sos
+  elif tIsDebianCompatible; then
+    tPackageUpgrade bash ssh ca-certificates sudo
+  fi
 }
 
 @test "subscribe and attach channels" {


### PR DESCRIPTION
Previously generated this output on Ubuntu 14.04:

    (from function `tPackageUpgrade' in file /usr/bin/os_helper.bash, line 102,
    in test file /usr/bin/fb-install-foreman.bats, line 81)
    `tPackageUpgrade bash openssh ca-certificates sudo selinux-policy\* yum\* abrt\* sos' failed with status 100
    Reading package lists...
    Building dependency tree...
    Reading state information...
    E: Unable to locate package openssh
    E: Unable to locate package sos
