### PR TITLE
Fixed pool starting and kickstart option

### DIFF
--- a/fb-setup-libvirt.bats
+++ b/fb-setup-libvirt.bats
@@ -60,6 +60,7 @@ EON
 </pool>
 EOP
   virsh pool-define /tmp/nested.xml
+  virsh pool-start nested
   virsh pool-autostart nested
 }
 
@@ -106,7 +107,7 @@ EOP
 }
 
 @test "associate partition table" {
-  hammer -d os add-ptable --id 1 --ptable "Kickstart default"
+  hammer -d os add-ptable --id 1 --partition-table "Kickstart default"
 }
 
 @test "associate installation media" {
@@ -163,12 +164,8 @@ EOP
     --subnet nested.lan \
     --operatingsystem-id 1 \
     --medium-id 1 \
-    --ptable "Kickstart default" \
+    --partition-table "Kickstart default" \
     --puppet-proxy-id 1 \
     --puppet-ca-proxy-id 1 \
     --environment production
-}
-
-@test "run foreman-debug" {
-  foreman-debug -q -d /root/foreman-debug || true
 }


### PR DESCRIPTION
One note - for nested libvirt via Foreman you are missing last bit - to be able
to define CPU features in the UI. It will always fail with "Call to
virDomainDefineXML failed: unknown OS type hvm" because CPU type must be set to
"host" or to have hypervisor capability.

I briefly searched in fog/libvirt but I was unable to find how to provide this
bit. If you know how to do that, please do the patch for me into Foreman :-)