### PR TITLE
Do not fail on agent exit code 2

### DIFF
--- a/fb-setup-libvirt.bats
+++ b/fb-setup-libvirt.bats
@@ -83,7 +83,7 @@ EOP
 }
 
 @test "refresh puppet facts" {
-  puppet agent -t -v
+  puppet agent -v -o --no-daemonize
 }
 
 @test "create nested libvirt compute resource" {


### PR DESCRIPTION
For some reason, puppet agent exits with "2" on success (RHEL6). Help page says
nothing about exit codes and only mention the special `--detailed-exitcodes`
which we do not provide. Google also tells me nothing. Because agent return
codes are not important for our tests, I am giving it true.

```
 ✗ refresh puppet facts
   (in test file fb-setup-libvirt.bats, line 86)
     `puppet agent -t -v' failed with status 2
   info: Retrieving plugin
   info: Loading facts in /var/lib/puppet/lib/facter/pe_version.rb
   info: Loading facts in /var/lib/puppet/lib/facter/facter_dot_d.rb
   info: Loading facts in /var/lib/puppet/lib/facter/root_home.rb
   info: Loading facts in /var/lib/puppet/lib/facter/puppet_vardir.rb
   info: Caching catalog for hp-dl580g7-02.rhts.eng.bos.redhat.com
   info: Applying configuration version '1425256569'
   notice: /File[/etc/ntp.conf]/content: 
   --- /etc/ntp.conf    2015-03-02 06:54:40.111510322 -0500
   +++ /tmp/puppet-file20150302-45635-2ilkvy-0  2015-03-02 06:58:10.703510092 -0500
   @@ -21,6 +21,4 @@
    
    # Driftfile.
    driftfile /var/lib/ntp/drift
   -server 10.16.71.254  # added by /sbin/dhclient-script
   -server 10.5.26.10  # added by /sbin/dhclient-script
   -server 10.5.27.10  # added by /sbin/dhclient-script
   +
   
   info: FileBucket adding {md5}1a5eb43992e1ed63e731b79dcaceb844
   info: /File[/etc/ntp.conf]: Filebucketed /etc/ntp.conf to puppet with sum 1a5eb43992e1ed63e731b79dcaceb844
   notice: /File[/etc/ntp.conf]/content: content changed '{md5}1a5eb43992e1ed63e731b79dcaceb844' to '{md5}60f05f47809aa69d4dddb9dae8db528f'
   info: Class[Ntp::Config]: Scheduling refresh of Class[Ntp::Service]
   info: Class[Ntp::Service]: Scheduling refresh of Service[ntp]
   notice: /Stage[main]/Ntp::Service/Service[ntp]: Triggered 'refresh' from 1 events
   notice: Finished catalog run in 0.89 seconds
```