### PR TITLE
Install foreman-release from custom repo

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -95,8 +95,6 @@ setup() {
 
 @test "configure repository" {
   if tIsRedHatCompatible; then
-    rpm -q foreman-release || yum -y install $FOREMAN_URL
-
     if [ -n "$FOREMAN_CUSTOM_URL" ]; then
       cat > /etc/yum.repos.d/foreman-custom.repo <<EOF
 [foreman-custom]
@@ -105,7 +103,10 @@ enabled=1
 gpgcheck=0
 baseurl=${FOREMAN_CUSTOM_URL}
 EOF
+      rpm -q foreman-release || yum -y install foreman-release
       yum-config-manager --disable foreman
+    else
+      rpm -q foreman-release || yum -y install $FOREMAN_URL
     fi
   elif tIsDebianCompatible; then
     echo "deb ${FOREMAN_CUSTOM_URL:-http://deb.theforeman.org/} ${OS_RELEASE} ${FOREMAN_REPO}" > /etc/apt/sources.list.d/foreman.list


### PR DESCRIPTION
Previously it would try and install foreman-release.rpm from the primary
yum.tf.org repos, which wouldn't exist for a brand new release yet.

Now when using a custom repo, simply install foreman-release from there
instead.

(foreman-release is used as it helps configure the plugin repos)

---

Sorry, a bit of an urgent one to be able to release RC1.  I've no idea how I managed to do 1.7.0-RC1 last time, unless I just pushed it despite the initial test failure, or this code was different.

http://ci.theforeman.org/job/systest_foreman/5912/console is the failed run.  Seems to work from vagrant here:

<pre>
✔ ~/code/foreman/foreman-bats [custom-release-rpm L|…2⚑ 3] 
08:26 $ echo FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-1.8/RHEL/7/x86_64/ FOREMAN_REPO=releases/1.8 fb-install-foreman.bats | vagrant ssh el7                                                                                                             
1..29
ok 1 # skip (Puppet package not installed) stop puppet agent (if installed)
ok 2 # skip (Puppet not installed, or SSL directory doesn't exist) clean after puppet (if installed)
ok 3 # skip (Puppet not installed, or 'server' not configured) make sure puppet not configured to other pm
ok 4 wait max 30 secs until network is up
ok 5 install SELinux tools
ok 6 update important system packages
ok 7 # skip (No subscription-manager credentials and pool id) subscribe and attach channels
ok 8 enable epel
ok 9 configure repository
ok 10 install installer
....
</pre>