### PR TITLE
add workaround for Debian bug #782325

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -149,6 +149,9 @@ EOF
 @test "check for no changes when running the installer" {
   [ x$FOREMAN_VERSION = "x1.5" -o x$FOREMAN_VERSION = "x1.4" ] && skip "Only supported on 1.6+"
   tIsDebianCompatible && [ x$OS_RELEASE = xsqueeze -o x$OS_RELEASE = xprecise ] && skip "Known bug #6520"
+  if [ "x${OS_RELEASE}" = "xjessie" ]; then
+    mkdir /etc/puppet/files # workaround for Debian bug #782325
+  fi
   foreman-installer --no-colors -v --detailed-exitcodes
   [ $? -eq 0 ]
 }


### PR DESCRIPTION
The proposed fix for upstream is not to reference the directory which isn't
brought or created by the packages in fileserver.conf. Here it's much easier
just to create the directory.

See http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=782325 for the Debian bug report and i.e. http://ci.theforeman.org/view/Status/job/systest_foreman/6125/console for the actual problem.