### PR TITLE
Use apt-get --only-upgrade instead of apt-get upgrade

### DIFF
--- a/bootstrap_vagrant.sh
+++ b/bootstrap_vagrant.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 set -xe
 type git || yum -y install git || (apt-get update; apt-get -y install git)
-if grep -q ^8 /etc/debian_version ; then
-  # Problem with mirror.rackspace.com
-  echo "deb http://ftp.debian.org/debian/ jessie main contrib non-free\ndeb http://security.debian.org/ jessie/updates main contrib non-free" >/etc/apt/sources.list
-  apt-get update
-fi
 git clone https://github.com/sstephenson/bats.git && bats/install.sh /usr
 /vagrant/install.sh /usr

--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -81,7 +81,7 @@ setup() {
   if tIsRedHatCompatible; then
     tPackageUpgrade bash openssh ca-certificates sudo selinux-policy\* yum\* abrt\* sos
   elif tIsDebianCompatible; then
-    tPackageUpgrade bash ssh ca-certificates sudo
+    tPackageUpgrade bash openssh-client ca-certificates sudo
   fi
 }
 

--- a/os_helper.bash
+++ b/os_helper.bash
@@ -101,7 +101,7 @@ tPackageUpgrade() {
     yum -y upgrade $*
   elif tIsDebianCompatible; then
     export DEBIAN_FRONTEND=noninteractive
-    apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade $*
+    apt-get -y --only-upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install $*
   else
     false # not implemented
   fi


### PR DESCRIPTION
This works better as it upgrades other necessary packages.  Also fixed the
name of the ssh package, as 'ssh' has long been obsolete and isn't actually
the OpenSSH client's package name.

---

The hope is that it fixes this error: http://ci.theforeman.org/job/systest_foreman/6178/tapTestReport/fb-install-foreman.bats.out-6/

I tested it manually:

<pre>
root@jessietest1:~# dpkg -l openssh*
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                      Version                   Architecture              Description
+++-=========================================-=========================-=========================-=======================================================================================
ii  openssh-client                            1:6.7p1-3                 amd64                     secure shell (SSH) client, for secure access to remote machines
ii  openssh-server                            1:6.7p1-3                 amd64                     secure shell (SSH) server, for secure access from remote machines
ii  openssh-sftp-server                       1:6.7p1-3                 amd64                     secure shell (SSH) sftp server module, for SFTP access from remote machines
root@jessietest1:~# apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade bash openssh-client ca-certificates sudo
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Calculating upgrade... bash is already the newest version.
ca-certificates is already the newest version.
ca-certificates set to manually installed.
sudo is already the newest version.
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 openssh-server : Depends: openssh-client (= 1:6.7p1-3) but 1:6.7p1-5 is to be installed
 openssh-sftp-server : Depends: openssh-client (= 1:6.7p1-3) but 1:6.7p1-5 is to be installed
E: Broken packages
root@jessietest1:~# apt-get -y --only-upgrade -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install bash openssh-client ca-certificates sudo
Reading package lists... Done
Building dependency tree       
Reading state information... Done
bash is already the newest version.
ca-certificates is already the newest version.
sudo is already the newest version.
The following extra packages will be installed:
  openssh-server openssh-sftp-server
Suggested packages:
  ssh-askpass libpam-ssh keychain monkeysphere rssh molly-guard ufw
The following packages will be upgraded:
  openssh-client openssh-server openssh-sftp-server
3 upgraded, 0 newly installed, 0 to remove and 70 not upgraded.
Need to get 1,060 kB of archives.
After this operation, 2,048 B of additional disk space will be used.
Get:1 http://ftp.debian.org/debian/ jessie/main openssh-sftp-server amd64 1:6.7p1-5 [37.9 kB]
Get:2 http://ftp.debian.org/debian/ jessie/main openssh-server amd64 1:6.7p1-5 [330 kB]
Get:3 http://ftp.debian.org/debian/ jessie/main openssh-client amd64 1:6.7p1-5 [691 kB]
Fetched 1,060 kB in 2s (371 kB/s)       
Preconfiguring packages ...
(Reading database ... 30664 files and directories currently installed.)
Preparing to unpack .../openssh-sftp-server_1%3a6.7p1-5_amd64.deb ...
Unpacking openssh-sftp-server (1:6.7p1-5) over (1:6.7p1-3) ...
Preparing to unpack .../openssh-server_1%3a6.7p1-5_amd64.deb ...
Unpacking openssh-server (1:6.7p1-5) over (1:6.7p1-3) ...
Preparing to unpack .../openssh-client_1%3a6.7p1-5_amd64.deb ...
Unpacking openssh-client (1:6.7p1-5) over (1:6.7p1-3) ...
Processing triggers for man-db (2.7.0.2-5) ...
........
</pre>

(Note that this is now the same upgrade command we use in Foreman's own upgrade steps.)