### PR TITLE
Use 2 or more vcpus

### DIFF
--- a/virt-spawn
+++ b/virt-spawn
@@ -250,6 +250,7 @@ $SUDO virt-builder $DISTRO \
 echo "Spawning new VM with MAC address $MAC"
 $SUDO virt-install --import \
   --cpu host \
+  --vcpus $(nproc) \
   --os-variant $OSVARIANT \
   --name $FQDN \
   --ram $RAM \


### PR DESCRIPTION
Virt-spawn is only confitured with one VCPU, looks like for larger instances I
could leverage much more. This spawns with two cores plus ability to hoplug up
to MAX cpus on demand.

Test this pleas on non-Red Hat platforms. Fedora works fine, RHEL7 as well (as
a host).