### PR TITLE
Add Fedora 21 support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ boxes = [
   {:name => 'jessie',   :libvirt => 'fm-debian8',    :image_name => 'Debian.*Jessie', :os_user => 'debian'},
   {:name => 'f19',      :libvirt => 'fm-fedora19',   :image_name => 'Fedora.*19',                 :pty => true},
   {:name => 'f20',      :libvirt => 'fm-fedora20',   :image_name => 'Fedora.*20',                 :pty => true},
+  {:name => 'f21',      :libvirt => 'fm-fedora21',   :image_name => 'Fedora.*21',                 :pty => true},
   {:name => 'el6',      :libvirt => 'fm-centos64',   :image_name => 'CentOS 6', :default => true, :pty => true},
   {:name => 'el7',      :libvirt => 'fm-centos70',   :image_name => 'CentOS 7', :default => true, :pty => true},
 ]

--- a/os_helper.bash
+++ b/os_helper.bash
@@ -50,7 +50,7 @@ tIsFedora() {
 
 tIsRHEL() {
   if [ -z "$1" ]; then
-    tIsRedHatCompatible
+    tIsRedHatCompatible && ! tIsFedoraCompatible
   else
     tSetOSVersion
     tIsRedHatCompatible && [[ "$1" -eq "$OS_VERSION" ]]


### PR DESCRIPTION
Packages are built on Koji and a run against Rackspace locally (with FOREMAN_CUSTOM_URL etc.) seems to be OK:

<pre>
15:57 $ vagrant ssh f21 -c 'FOREMAN_CUSTOM_URL=http://koji.katello.org/releases/yum/foreman-nightly/Fedora/21/x86_64/ /vagrant/fb-install-foreman.bats'
 ✓ stop puppet agent (if installed)
 ✓ clean after puppet (if installed)
 ✓ make sure puppet not configured to other pm
 ✓ wait max 30 secs until network is up
 ✓ install SELinux tools
 ✓ update important system packages
 - subscribe and attach channels (skipped: Not required)
 - enable epel (skipped: Not required)
 ✓ configure repository
 ✓ install installer
 ✓ run the installer
 ✓ check for no changes when running the installer
 ✓ wait 10 seconds
 ✓ check web app is up
 ✓ check smart proxy is registered and Hammer runs
 ✓ install all compute resources
 ✓ check web app is up after CR installation
 ✓ collect important logs

18 tests, 0 failures, 2 skipped
</pre>