### PR TITLE
Configure PL nightly GPG key to authenticate packages

### DIFF
--- a/fb-install-plpuppet.bats
+++ b/fb-install-plpuppet.bats
@@ -58,6 +58,7 @@ load os_helper
       http://nightlies.puppetlabs.com/puppet-agent-latest/repo_configs/deb/pl-puppet-agent-latest-${OS_RELEASE}.list
     curl -o /etc/apt/sources.list.d/puppetserver-nightlies.list \
       http://nightlies.puppetlabs.com/puppetserver-latest/repo_configs/deb/pl-puppetserver-latest-${OS_RELEASE}.list
+    apt-key adv --keyserver pgp.mit.edu --recv-keys 8735F5AF62A99A628EC13377B8F999C007BB6C57
     apt-get update
   fi
 }


### PR DESCRIPTION
Should fix: http://ci.theforeman.org/job/systest_foreman/9501/console

The key on the website is expired ([CPR-347](https://tickets.puppetlabs.com/browse/CPR-347)) so the version on the keyserver is necessary for now.