### PR TITLE
Ignore failures stopping iptables when absent

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -27,7 +27,8 @@ setup() {
   if tFileExists /usr/sbin/firewalld; then
     tServiceStop firewalld; tServiceDisable firewalld
   else
-    tServiceStop iptables; tServiceDisable iptables
+    tServiceStop iptables || true  # ignore if missing
+    tServiceDisable iptables || true
   fi
 
   tPackageExists curl || tPackageInstall curl


### PR DESCRIPTION
Since 92d8a0d tests on Debian failed as the service may not be
installed.