### PR TITLE
Don't use Rackspace Orchestration images

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
         override.vm.box = 'dummy'
         p.server_name = machine.vm.hostname
         p.flavor = /#{memory_rs} Performance/
-        p.image = Regexp.new(box[:image_name] + '.*PV')
+        p.image = Regexp.new(box[:image_name] + '.*PV(?!.*Orchestration)')
         override.ssh.pty = true if box[:pty]
       end
 


### PR DESCRIPTION
Some Rackspace images containing a pre-installed version of Puppet
exist with the name:

    Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM) (Orchestration)

vs.

    Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)

This changes the image regexp to ignore them so we get the regular OS
image without Puppet, instead of needing to upgrade/downgrade from the
preinstalled version.