### PR TITLE
Add test to check Foreman is expected version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The following environment variables can be specified:
 * `FOREMAN_USE_ORGANIZATIONS`: whether to use organizations or not (value can be true/false)
 * `FOREMAN_USE_LOCATIONS`: whether to use locations or not (value can be true/false).
 * `FOREMAN_ADMIN_PASSWORD`: initial admin password (defaults to "admin")
+* `FOREMAN_EXPECTED_VERSION`: version number of Foreman and components that is expected to be
+  installed
 
 ### Foreman Puppet integration test (fb-puppet-tests.bats)
 

--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -149,6 +149,12 @@ EOF
   [ $? -eq 0 ]
 }
 
+@test "assert correct Foreman version is installed" {
+  [ -n "$FOREMAN_EXPECTED_VERSION" ] || skip "FOREMAN_EXPECTED_VERSION is not set, not asserting"
+  # prints and fails if any VERSION files don't match expected version
+  ! grep -v -H -x "$FOREMAN_EXPECTED_VERSION" /usr/share/foreman*/VERSION
+}
+
 @test "wait 10 seconds" {
   sleep 10
 }


### PR DESCRIPTION
FOREMAN_EXPECTED_VERSION can now be passed to the fb-install-foreman
test, which causes it to check all VERSION files match this exact
version number. This can be used for release testing to check all
packages were built and the correct ones are being tested.

---

Generates this output when tested with `FOREMAN_EXPECTED_VERSION=1.12.0-RC1` against RC2:

<pre>
 ✗ assert correct Foreman version is installed
   (in test file /usr/bin/fb-install-foreman.bats, line 153)
     `[ -n "$FOREMAN_EXPECTED_VERSION" ] || skip "FOREMAN_EXPECTED_VERSION is not set, not asserting"' failed
   /usr/share/foreman-installer/VERSION:1.12.0-RC2
   /usr/share/foreman-proxy/VERSION:1.12.0-RC2
   /usr/share/foreman/VERSION:1.12.0-RC2
</pre>