### PR TITLE
Wait for system boot completion before running package manager

### DIFF
--- a/bootstrap_vagrant.sh
+++ b/bootstrap_vagrant.sh
@@ -1,5 +1,26 @@
 #!/bin/sh
 set -xe
+
+# Wait for boot to complete, in case cloud-init, rc.local etc. are using the
+# package database
+if type systemctl; then
+  while true; do
+    state=$(systemctl is-system-running || true)
+    if [ x$state = xrunning ]; then
+      break
+    elif [ x$state = xdegraded ]; then
+      (
+        echo "System state is degraded, failed services:"
+        systemctl --failed --no-pager
+        echo "continuing anyway..."
+      ) >&2
+      break
+    else
+      sleep 1
+    fi
+  done
+fi
+
 type git || yum -y install git || (apt-get update; apt-get -y install git)
 git clone https://github.com/sstephenson/bats.git && bats/install.sh /usr
 /vagrant/install.sh /usr


### PR DESCRIPTION
Rackspace Debian Stretch boxes are sometimes failing during bootstrap
with a locking error indicating the image's rc.local script is still
running dpkg/debconf commands:

    debconf: DbDriver "config": /var/cache/debconf/config.dat is locked by another process: Resource temporarily unavailable
    dpkg: error processing package less (--configure):
     subprocess installed post-installation script returned error exit status 1

Waiting until the completion of all boot stages, including cloud-init
and rc.local should ensure the bootstrap and tests themselves are the
only processes running.