### PR TITLE
add entires to /etc/hosts on Debian

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -23,6 +23,10 @@ setup() {
     setenforce 0
   fi
 
+  if tIsDebianCompatible; then
+    for ip in `hostname -I` ; do echo $ip `hostname` ; done >>/etc/hosts
+  fi
+
   # disable firewall
   if tFileExists /usr/sbin/firewalld; then
     tServiceStop firewalld; tServiceDisable firewalld


### PR DESCRIPTION
This should fix the errors currently seen on Debian/stretch systests. Rackspace did update their base image and it seems cloud-init does not set these entires in /etc/hosts anymore.