### PR TITLE
Add custom plugins url when installing foreman

### DIFF
--- a/fb-install-foreman.bats
+++ b/fb-install-foreman.bats
@@ -105,6 +105,7 @@ EOF
       # switch back to the newly installed repo definition to inherit its GPG settings
       yum-config-manager --disable foreman-custom
       sed -i "s|^baseurl.*|baseurl=${FOREMAN_CUSTOM_URL}|" /etc/yum.repos.d/foreman.repo
+      sed -i "s|^baseurl.*|baseurl=${FOREMAN_CUSTOM_PLUGINS_URL}|" /etc/yum.repos.d/foreman-plugins.repo
     else
       rpm -q foreman-release || yum -y install $FOREMAN_URL
     fi


### PR DESCRIPTION
We have custom url for foreman, but not for plugins.
This causes failures when using koji because foreman-release
provides both foreman.repo and foreman-plugins.repo.

If you run the systest as a part of release process,
plugins repo points to the yum.theforeman.org instead of koji.